### PR TITLE
Hotfix/fix post edit creation

### DIFF
--- a/blog/views/post_edit.py
+++ b/blog/views/post_edit.py
@@ -6,8 +6,15 @@ from django.contrib.auth.decorators import login_required
 def post_edit(request, pk):
     post = get_object_or_404(Post, pk=pk)
     if request.method == "POST":
-        post.title = request.POST.get('title')
-        post.content = request.POST.get('content')
+        title = request.POST.get('title')
+        content = request.POST.get('content')
+
+        if not title or not content:
+            return render(request, "blog/post_edit.html", {"post": post, "error": "Title and content cannot be empty."})
+
+        post.title = title
+        post.content = content
         post.save()
         return redirect('post_detail', pk=post.pk)
-    return render(request, 'blog/post_form.html', {'post': post})
+
+    return render(request, 'blog/post_edit.html', {'post': post})

--- a/templates/blog/post_edit.html
+++ b/templates/blog/post_edit.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+{% load static %}
+{% load i18n %}
+
+{% block title %}{% trans "Edit Post" %}{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <h1 class="mb-4">{% trans "Edit Post" %}</h1>
+
+    <form method="post" id="postEditForm" class="card p-4 shadow">
+        {% csrf_token %}
+
+        <div class="mb-3">
+            <label for="title" class="form-label">{% trans "Title" %}:</label>
+            <input type="text" id="title" name="title" class="form-control" value="{{ post.title }}">
+        </div>
+
+        <div class="mb-3">
+            <label for="content" class="form-label">{% trans "Content" %}:</label>
+            <textarea id="content" name="content" class="form-control" rows="6">{{ post.content }}</textarea>
+        </div>
+
+        <div class="d-flex justify-content-between">
+            <button type="submit" class="btn btn-success">{% trans "Save Changes" %}</button>
+            <a href="{% url 'post_detail' post.pk %}" class="btn btn-secondary">{% trans "Cancel" %}</a>
+        </div>
+    </form>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Description
This PR fixes the issue where editing a post was unintentionally creating a new post. The following changes were made:

- Created a new post_edit.html template to properly edit an existing post.
- Updated post_edit view to ensure the correct form is displayed and that posts are properly updated.
- Added validation to prevent empty titles or content from being submitted.
- Redirects correctly to post_detail after editing.

## Screenshot
![image](https://github.com/user-attachments/assets/8d770af2-206f-4243-ad62-58cee4bbdafa)

## Related Issues
Closes #3  

## Checklist
- [ x ] Code follows the project style guidelines
- [ x ] Tests pass
- [ x ] Documentation updated
